### PR TITLE
Return raw reasoning in API

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ print(resp.json())
 
 The JSON response now also includes `raw_response` containing the exact
 portfolio manager output and `messages`, a history of the agent
-conversation. These can be saved and displayed to users for additional
+conversation. Each message has a `role`, optional `name`, and
+`content`. These can be saved and displayed to users for additional
 context.
 
 The service relies on the same environment variables (`OPENAI_API_KEY`, `FINANCIAL_DATASETS_API_KEY`, etc.) used by the CLI.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ curl -X POST http://localhost:8000/trade \
   -d '{"tickers": ["AAPL","MSFT"], "analysts": ["michael_burry"], "model_name": "gpt-4o"}'
 ```
 
+If you plan to use local models with `model_provider` set to `Ollama`, make sure
+the model is already pulled into the Ollama container. For example:
+
+```bash
+docker exec ollama ollama pull gemma3:4b
+```
+
 Using Python with `requests`:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ resp = requests.post("http://localhost:8000/trade", json=payload)
 print(resp.json())
 ```
 
+The JSON response now also includes `raw_response` containing the exact
+portfolio manager output and `messages`, a history of the agent
+conversation. These can be saved and displayed to users for additional
+context.
+
 The service relies on the same environment variables (`OPENAI_API_KEY`, `FINANCIAL_DATASETS_API_KEY`, etc.) used by the CLI.
 
 

--- a/app/backend/routes/hedge_fund.py
+++ b/app/backend/routes/hedge_fund.py
@@ -78,7 +78,14 @@ async def run_hedge_fund(request: HedgeFundRequest):
                         pass
 
                 # Get the final result
-                result = run_task.result()
+                try:
+                    result = run_task.result()
+                except RuntimeError as e:
+                    yield ErrorEvent(message=str(e)).to_sse()
+                    return
+                except Exception as e:
+                    yield ErrorEvent(message=f"{e}").to_sse()
+                    return
 
                 if not result or not result.get("messages"):
                     yield ErrorEvent(message="Failed to generate hedge fund decisions").to_sse()

--- a/app/backend/routes/hedge_fund.py
+++ b/app/backend/routes/hedge_fund.py
@@ -84,11 +84,20 @@ async def run_hedge_fund(request: HedgeFundRequest):
                     yield ErrorEvent(message="Failed to generate hedge fund decisions").to_sse()
                     return
 
-                # Send the final result
+                # Send the final result including raw response
                 final_data = CompleteEvent(
                     data={
                         "decisions": parse_hedge_fund_response(result.get("messages", [])[-1].content),
                         "analyst_signals": result.get("data", {}).get("analyst_signals", {}),
+                        "raw_response": result.get("messages", [])[-1].content,
+                        "messages": [
+                            {
+                                "type": getattr(m, "type", type(m).__name__),
+                                "name": getattr(m, "name", None),
+                                "content": getattr(m, "content", ""),
+                            }
+                            for m in result.get("messages", [])
+                        ],
                     }
                 )
                 yield final_data.to_sse()

--- a/app/backend/routes/hedge_fund.py
+++ b/app/backend/routes/hedge_fund.py
@@ -92,7 +92,7 @@ async def run_hedge_fund(request: HedgeFundRequest):
                         "raw_response": result.get("messages", [])[-1].content,
                         "messages": [
                             {
-                                "type": getattr(m, "type", type(m).__name__),
+                                "role": getattr(m, "type", type(m).__name__),
                                 "name": getattr(m, "name", None),
                                 "content": getattr(m, "content", ""),
                             }

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -32,17 +32,20 @@ async def trade(req: TradeRequest):
     start_date, end_date = default_dates(req.start_date, req.end_date)
     portfolio = create_portfolio(req.initial_cash, req.margin_requirement, req.tickers)
     runner = HedgeFundRunner(req.analysts)
-    result = await run_in_threadpool(
-        runner.run,
-        req.tickers,
-        start_date,
-        end_date,
-        portfolio,
-        req.show_reasoning,
-        req.model_name,
-        req.model_provider,
-    )
-    return result
+    try:
+        result = await run_in_threadpool(
+            runner.run,
+            req.tickers,
+            start_date,
+            end_date,
+            portfolio,
+            req.show_reasoning,
+            req.model_name,
+            req.model_provider,
+        )
+        return result
+    except RuntimeError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
 
 class BacktestRequest(BaseModel):

--- a/src/hedgefund/core.py
+++ b/src/hedgefund/core.py
@@ -49,9 +49,24 @@ class HedgeFundRunner:
                     },
                 }
             )
+
+            final_message = final_state["messages"][-1]
+            raw_response = getattr(final_message, "content", str(final_message))
+
+            history = [
+                {
+                    "type": getattr(m, "type", type(m).__name__),
+                    "name": getattr(m, "name", None),
+                    "content": getattr(m, "content", ""),
+                }
+                for m in final_state.get("messages", [])
+            ]
+
             return {
-                "decisions": parse_hedge_fund_response(final_state["messages"][-1].content),
+                "decisions": parse_hedge_fund_response(raw_response),
                 "analyst_signals": final_state["data"]["analyst_signals"],
+                "raw_response": raw_response,
+                "messages": history,
             }
         finally:
             progress.stop()

--- a/src/hedgefund/core.py
+++ b/src/hedgefund/core.py
@@ -4,6 +4,7 @@ from dateutil.relativedelta import relativedelta
 
 from langgraph.graph import END, StateGraph
 from langchain_core.messages import HumanMessage
+from src.utils.ollama import is_model_available
 
 from src.agents.portfolio_manager import portfolio_management_agent
 from src.agents.risk_manager import risk_management_agent
@@ -31,6 +32,12 @@ class HedgeFundRunner:
     ) -> dict:
         """Execute the trading workflow."""
         progress.start()
+
+        if model_provider.lower() == "ollama":
+            if not is_model_available(model_name):
+                raise RuntimeError(
+                    f"Ollama model '{model_name}' not found. Pull it with `ollama pull {model_name}`"
+                )
         try:
             final_state = self.app.invoke(
                 {

--- a/src/hedgefund/core.py
+++ b/src/hedgefund/core.py
@@ -55,7 +55,7 @@ class HedgeFundRunner:
 
             history = [
                 {
-                    "type": getattr(m, "type", type(m).__name__),
+                    "role": getattr(m, "type", type(m).__name__),
                     "name": getattr(m, "name", None),
                     "content": getattr(m, "content", ""),
                 }

--- a/src/utils/ollama.py
+++ b/src/utils/ollama.py
@@ -61,6 +61,19 @@ def get_locally_available_models() -> List[str]:
         return []
 
 
+def is_model_available(model_name: str, base_url: str | None = None) -> bool:
+    """Check if a given Ollama model is available."""
+    base_url = base_url or os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+    try:
+        response = requests.get(f"{base_url}/api/tags", timeout=5)
+        if response.status_code == 200:
+            models = response.json().get("models", [])
+            return any(m.get("name") == model_name for m in models)
+    except requests.RequestException:
+        pass
+    return False
+
+
 def start_ollama_server() -> bool:
     """Start the Ollama server if it's not already running."""
     if is_ollama_server_running():


### PR DESCRIPTION
## Summary
- expose raw portfolio manager response and history of messages when running the hedge fund
- include additional info in the SSE output
- document new fields returned by the `/trade` endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af075bd4c8323ae38df92ec626ad6